### PR TITLE
Add GitHub links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,3 +49,5 @@ VignetteBuilder:
     knitr
 Biarch: true
 biocViews: AssayDomain, Infrastructure
+URL: https://github.com/stemangiola/tidygate
+BugReports: https://github.com/stemangiola/tidygate/issues


### PR DESCRIPTION
This makes it easier for folks to find the source of your package on CRAN