### PR TITLE
Use lifecycle helper to check for deprecation

### DIFF
--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -71,15 +71,14 @@ test_that("gate grouping", {
 test_that("gate DEPRECATED", {
   library(dplyr)
   
-
-    tidygate::tidygate_data  %>%
-    mutate(sh = factor(hierarchy)) %>%
+  data <- mutate(tidygate_data, sh = factor(hierarchy))
+  lifecycle::expect_deprecated(
     gate(
-      .element = c(`ct 1`, `ct 2`),
-      Dim1, Dim2,
-      gate_list = tidygate::gate_list
-    ) %>%
-      capture_warnings() %>%
-      expect_match("is deprecated as of tidygate 0.3.0.")
-  
+      data, 
+      .element = c(`ct 1`, `ct 2`), 
+      Dim1, 
+      Dim2, 
+      gate_list = gate_list
+    )
+  )
 })


### PR DESCRIPTION
This ensures that your test doesn't fail in the upcoming lifecycle 1.0.0 release, where the wording has been tweaked slightly.