### PR TITLE
Use a character `"0"` as the replacement value

### DIFF
--- a/R/functions_OLD.R
+++ b/R/functions_OLD.R
@@ -428,7 +428,7 @@ gate_programmatic <-
                  by = quo_names(.element)) %>%
       
       # Replace NAs
-      mutate(!!name := replace_na(!!as.symbol(name), 0)) %>%
+      mutate(!!name := replace_na(!!as.symbol(name), "0")) %>%
       
       # Add internals the list of gates
       add_attr(gate_list, "gate") 

--- a/R/functions_OLD.R
+++ b/R/functions_OLD.R
@@ -322,7 +322,7 @@ gate_interactive <-
                  by = quo_names(.element)) %>%
       
       # Replace NAs
-      mutate(!!name := replace_na(!!as.symbol(name), 0)) %>%
+      mutate(!!name := replace_na(!!as.symbol(name), "0")) %>%
       
       # Add internals the list of gates
       add_attr(map(gate_list, ~ attr(.x, "gate")), "gate") 


### PR DESCRIPTION
We are updating `tidyr::replace_na()` to utilize vctrs, and that results in slightly stricter / more correct type conversions. See https://github.com/tidyverse/tidyr/pull/1219

We noticed in revdeps that this package broke. An easy way to see this is by installing the PR mentioned above and running:

``` r
library(tidygate)

gate(
  tidygate::tidygate_data,
  .element = c(`ct 1`, `ct 2`),
  Dim1, Dim2,
  gate_list = tidygate::gate_list
)
#> Warning: `gate()` was deprecated in tidygate 0.3.0.
#> Please use `gate_chr()` instead.
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated.
#> Error: Problem with `mutate()` column `gate`.
#> ℹ `gate = replace_na(gate, 0)`.
#> x Can't convert `replace` <double> to match type of `data` <character>.
```

<sup>Created on 2021-11-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

The problem boils down to the fact that you are calling `replace_na(<chr>, replace = 0)`, where the column you are replacing in (`gate`) is a character column, but the replacement value is a numeric value. This is no longer allowed. It looks like you actually did want a character column here for `gate` (based on the `unite()` call earlier, which returns a character vector), so I have changed `0` to `"0"`.

We would greatly appreciate if you could merge this PR and submit a patch release of your package to CRAN so we can send tidyr in!